### PR TITLE
Replacing current host + SPA in links to make Stache mark as active.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -394,9 +394,9 @@
       "dev": true
     },
     "@blackbaud/skyux-lib-stache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-stache/-/skyux-lib-stache-3.1.0.tgz",
-      "integrity": "sha512-PUDndBWuseQZQ6BZmyCGWMylRFig40vM9NWgZqWHMtdwbkLvhPStQf3uI0+ORwivBoZ1tnXj7N2IpRNpRxHz7Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-stache/-/skyux-lib-stache-3.2.1.tgz",
+      "integrity": "sha512-S6CuMR0Qma1vKm2DqaVZgISvvfWjyYPmuYkKiiSORyx4z8utrQgtNw3Z1ue/M6kym0XpvkLA/FRJpZnujadWjQ==",
       "dev": true,
       "requires": {
         "lodash.get": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@blackbaud/skyux-lib-clipboard": "1.1.1",
     "@blackbaud/skyux-lib-code-block": "1.3.1",
     "@blackbaud/skyux-lib-media": "1.0.1",
-    "@blackbaud/skyux-lib-stache": "3.1.0",
+    "@blackbaud/skyux-lib-stache": "3.2.1",
     "@pact-foundation/pact-web": "9.2.1",
     "@skyux-sdk/builder": "3.11.0",
     "@skyux-sdk/builder-plugin-skyux": "1.2.1",

--- a/src/app/public/modules/demo-page/demo-page.component.ts
+++ b/src/app/public/modules/demo-page/demo-page.component.ts
@@ -17,6 +17,10 @@ import {
 } from '@angular/router';
 
 import {
+  SkyAppConfig
+} from '@skyux/config';
+
+import {
   StacheNavLink
 } from '@blackbaud/skyux-lib-stache';
 
@@ -129,11 +133,14 @@ export class SkyDocsDemoPageComponent implements OnInit, AfterContentInit, After
     private activatedRoute: ActivatedRoute,
     private changeDetector: ChangeDetectorRef,
     private router: Router,
+    private skyAppConfig: SkyAppConfig,
     private supportalService: SkyDocsSupportalService,
     private titleService: SkyDocsDemoPageTitleService
   ) { }
 
   public ngOnInit(): void {
+    const currentHostUrl = this.skyAppConfig.skyux.host.url + '/' + this.skyAppConfig.skyux.name;
+
     this.updateTitle();
 
     this.supportalService
@@ -145,7 +152,8 @@ export class SkyDocsDemoPageComponent implements OnInit, AfterContentInit, After
           children: results.map((component: SkyDocsComponentInfo) => {
             return {
               name: component.name,
-              path: component.url
+              // Replace host + SPA so Stache will mark active
+              path: component.url.replace(currentHostUrl, '')
             };
           })
         }];


### PR DESCRIPTION
This allows "Popovers" (and all future separate SPAs) to still be marked as active in Stache.