### PR TITLE
Using external heading.

### DIFF
--- a/src/app/public/modules/demo-page/demo-page.component.ts
+++ b/src/app/public/modules/demo-page/demo-page.component.ts
@@ -148,14 +148,12 @@ export class SkyDocsDemoPageComponent implements OnInit, AfterContentInit, After
       .subscribe((results: SkyDocsComponentInfo[]) => {
         this.sidebarRoutes = [{
           name: 'Components',
-          path: '/',
-          children: results.map((component: SkyDocsComponentInfo) => {
-            return {
-              name: component.name,
-              // Replace host + SPA so Stache will mark active
-              path: component.url.replace(currentHostUrl, '')
-            };
-          })
+          path: 'https://developer.blackbaud.com/skyux/components',
+          children: results.map((component: SkyDocsComponentInfo) => ({
+            name: component.name,
+            // Replace host + SPA so Stache will mark active
+            path: component.url.replace(currentHostUrl, '')
+          }))
         }];
         this.changeDetector.markForCheck();
       });


### PR DESCRIPTION
To be used in https://github.com/blackbaud/skyux-popovers (and all SPAs) in conjunction with [Stache 3.2.3](https://github.com/blackbaud/skyux-lib-stache/blob/master/CHANGELOG.md#323-2019-12-10).