### PR TITLE
Add `reset` emitter to demo component

### DIFF
--- a/src/app/docs/sample/sample.component.html
+++ b/src/app/docs/sample/sample.component.html
@@ -9,6 +9,7 @@
 
   <sky-docs-demo>
     <sky-docs-demo-control-panel
+      (reset)="onDemoReset()"
       (selectionChange)="onDemoSelectionChange($event)"
     >
       <sky-docs-demo-control-panel-section>

--- a/src/app/docs/sample/sample.component.ts
+++ b/src/app/docs/sample/sample.component.ts
@@ -35,6 +35,10 @@ export class AppTypeDocComponent {
     return (placement === 'above' || placement === 'below');
   }
 
+  public onDemoReset(): void {
+    console.log('Reset button clicked!');
+  }
+
   public onDemoSelectionChange(change: SkyDocsDemoControlPanelChange): void {
     if (change.showTitle === true) {
       this.demoSettings.popoverTitle = 'Popover title';

--- a/src/app/public/modules/demo/demo-control-panel.component.html
+++ b/src/app/public/modules/demo/demo-control-panel.component.html
@@ -8,6 +8,7 @@
       <button
         class="sky-btn sky-btn-link"
         type="button"
+        [attr.data-test-selector]="'sky-docs-demo-control-panel-reset-button'"
         (click)="onResetButtonClick()"
       >
         {{ 'sky-docs-demo-control-panel-reset-button-label' | skyLibResources }}

--- a/src/app/public/modules/demo/demo-control-panel.component.ts
+++ b/src/app/public/modules/demo/demo-control-panel.component.ts
@@ -51,6 +51,12 @@ import {
 export class SkyDocsDemoControlPanelComponent implements OnDestroy, AfterContentInit {
 
   /**
+   * Fires when the user clicks the reset button.
+   */
+  @Output()
+  public reset = new EventEmitter<void>();
+
+  /**
    * Fires when a user makes a selection from one of the controls in the panel.
    */
   @Output()
@@ -81,6 +87,7 @@ export class SkyDocsDemoControlPanelComponent implements OnDestroy, AfterContent
   }
 
   public ngOnDestroy(): void {
+    this.reset.complete();
     this.selectionChange.complete();
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
@@ -94,6 +101,8 @@ export class SkyDocsDemoControlPanelComponent implements OnDestroy, AfterContent
     this.checkboxes.forEach((checkbox) => {
       checkbox.resetState();
     });
+
+    this.reset.emit();
   }
 
   private addEventListeners(): void {

--- a/src/app/public/modules/demo/demo.component.html
+++ b/src/app/public/modules/demo/demo.component.html
@@ -10,6 +10,7 @@
     <button *ngIf="hasOptions"
       class="sky-btn"
       type="button"
+      [attr.data-test-selector]="'sky-docs-demo-heading-button'"
       [ngClass]="{
         'sky-docs-demo-heading-btn-open': areOptionsVisible
       }"

--- a/src/app/public/modules/demo/demo.component.spec.ts
+++ b/src/app/public/modules/demo/demo.component.spec.ts
@@ -1,0 +1,51 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {
+  DemoFixturesModule
+} from './fixtures/demo-fixtures.module';
+
+import {
+  DemoFixtureComponent
+} from './fixtures/demo.component.fixture';
+
+describe('Demo component', () => {
+
+  let fixture: ComponentFixture<DemoFixtureComponent>;
+
+  function showControlPanel(): void {
+    const headingButton = fixture.nativeElement.querySelector('[data-test-selector="sky-docs-demo-heading-button"]');
+    headingButton.click();
+    fixture.detectChanges();
+  }
+
+  function resetControlPanel(): void {
+    const resetButton = fixture.nativeElement.querySelector('[data-test-selector="sky-docs-demo-control-panel-reset-button"]');
+    resetButton.click();
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        DemoFixturesModule
+      ]
+    });
+
+    fixture = TestBed.createComponent(DemoFixtureComponent);
+  });
+
+  describe('control panel component', () => {
+    it('should expose a `reset` emitter', () => {
+      const spy = spyOn(fixture.componentInstance, 'onDemoReset').and.callThrough();
+      fixture.detectChanges();
+
+      showControlPanel();
+      resetControlPanel();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/app/public/modules/demo/fixtures/demo-fixtures.module.ts
+++ b/src/app/public/modules/demo/fixtures/demo-fixtures.module.ts
@@ -1,0 +1,29 @@
+import {
+  CommonModule
+} from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyDocsDemoModule
+} from '../demo.module';
+
+import {
+  DemoFixtureComponent
+} from './demo.component.fixture';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SkyDocsDemoModule
+  ],
+  exports: [
+    DemoFixtureComponent
+  ],
+  declarations: [
+    DemoFixtureComponent
+  ]
+})
+export class DemoFixturesModule { }

--- a/src/app/public/modules/demo/fixtures/demo.component.fixture.html
+++ b/src/app/public/modules/demo/fixtures/demo.component.fixture.html
@@ -1,0 +1,37 @@
+<sky-docs-demo>
+  <sky-docs-demo-control-panel
+    (reset)="onDemoReset()"
+    (selectionChange)="onDemoSelectionChange($event)"
+  >
+    <sky-docs-demo-control-panel-section>
+      <sky-docs-demo-control-panel-radio-group
+        heading="Background color"
+        propertyName="backgroundColor"
+        [choices]="backgroundColors"
+        [initialValue]="'#f00'"
+      >
+      </sky-docs-demo-control-panel-radio-group>
+    </sky-docs-demo-control-panel-section>
+
+    <sky-docs-demo-control-panel-section>
+      <sky-docs-demo-control-panel-checkbox
+        label="Show icon"
+        propertyName="showIcon"
+        [checked]="true"
+      >
+      </sky-docs-demo-control-panel-checkbox>
+    </sky-docs-demo-control-panel-section>
+  </sky-docs-demo-control-panel>
+
+  <button
+    class="sky-btn"
+    type="button"
+    [ngStyle]="{
+      'background-color': demoSettings.backgroundColor
+    }"
+  >
+    <i *ngIf="demoSettings.showIcon"
+      class="fa fa-trash"
+    ></i> Sample button
+  </button>
+</sky-docs-demo>

--- a/src/app/public/modules/demo/fixtures/demo.component.fixture.ts
+++ b/src/app/public/modules/demo/fixtures/demo.component.fixture.ts
@@ -1,0 +1,30 @@
+import {
+  Component
+} from '@angular/core';
+
+import {
+  SkyDocsDemoControlPanelRadioChoice
+} from '../demo-control-panel-radio-choice';
+
+@Component({
+  selector: 'demo-fixture',
+  templateUrl: './demo.component.fixture.html'
+})
+export class DemoFixtureComponent {
+
+  public backgroundColors: SkyDocsDemoControlPanelRadioChoice[] = [
+    { value: '#f00', label: 'Red' },
+    { value: '#0f0', label: 'Green' },
+    { value: '#00f', label: 'Blue' }
+  ];
+
+  public demoSettings: {
+    backgroundColor?: string;
+    showIcon?: boolean;
+  } = {};
+
+  public onDemoReset(): void { }
+
+  public onDemoSelectionChange(): void { }
+
+}


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-docs-tools/issues/20

- Added initial fixtures for the demo component, as well as one test to verify the emitter works.
- Coverage will not be 100%; this is something we'll strive for over the next few releases.