### PR TITLE
Custom heading for demo component

### DIFF
--- a/src/app/docs/sample/sample.component.html
+++ b/src/app/docs/sample/sample.component.html
@@ -69,6 +69,12 @@
     </sky-popover>
   </sky-docs-demo>
 
+  <sky-docs-demo
+    heading="Sample demo heading"
+  >
+    Demo contents here.
+  </sky-docs-demo>
+
   <sky-docs-design-guidelines>
 
     <sky-docs-demo-page-section heading="Usage">

--- a/src/app/public/modules/demo-page/demo-page.component.html
+++ b/src/app/public/modules/demo-page/demo-page.component.html
@@ -14,21 +14,25 @@
       select="sky-docs-demo"
     ></ng-content>
 
-    <sky-tabset *ngIf="enableTabLayout else content"
-      permalinkId="docs"
+    <div
+      class="sky-docs-demo-page-main"
     >
-      <sky-tab tabHeading="Design">
-        <ng-content
-          select="sky-docs-design-guidelines"
-        ></ng-content>
-      </sky-tab>
+      <sky-tabset *ngIf="enableTabLayout else content"
+        permalinkId="docs"
+      >
+        <sky-tab tabHeading="Design">
+          <ng-content
+            select="sky-docs-design-guidelines"
+          ></ng-content>
+        </sky-tab>
 
-      <sky-tab tabHeading="Development">
-        <ng-container
-          [ngTemplateOutlet]="content"
-        ></ng-container>
-      </sky-tab>
-    </sky-tabset>
+        <sky-tab tabHeading="Development">
+          <ng-container
+            [ngTemplateOutlet]="content"
+          ></ng-container>
+        </sky-tab>
+      </sky-tabset>
+    </div>
   </stache>
 </div>
 

--- a/src/app/public/modules/demo-page/demo-page.component.scss
+++ b/src/app/public/modules/demo-page/demo-page.component.scss
@@ -58,3 +58,7 @@
     }
   }
 }
+
+.sky-docs-demo-page-main {
+  padding: $sky-padding-triple 0;
+}

--- a/src/app/public/modules/demo/demo.component.html
+++ b/src/app/public/modules/demo/demo.component.html
@@ -4,8 +4,11 @@
     class="sky-docs-demo-heading"
     role="heading"
   >
-    <span class="sky-section-heading">
-      {{ 'sky-docs-demo-heading' | skyLibResources }}
+    <span
+      class="sky-section-heading"
+      [attr.data-test-selector]="'sky-docs-demo-heading-text'"
+    >
+      {{ heading || ('sky-docs-demo-heading' | skyLibResources) }}
     </span>
     <button *ngIf="hasOptions"
       class="sky-btn"

--- a/src/app/public/modules/demo/demo.component.scss
+++ b/src/app/public/modules/demo/demo.component.scss
@@ -2,7 +2,7 @@
 @import '~@skyux/theme/scss/_compat/mixins';
 
 .sky-docs-demo {
-  margin-bottom: $sky-margin * 6;
+  margin-bottom: $sky-margin-double;
 }
 
 .sky-docs-demo-heading {

--- a/src/app/public/modules/demo/demo.component.spec.ts
+++ b/src/app/public/modules/demo/demo.component.spec.ts
@@ -4,6 +4,10 @@ import {
 } from '@angular/core/testing';
 
 import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
   DemoFixturesModule
 } from './fixtures/demo-fixtures.module';
 
@@ -35,6 +39,22 @@ describe('Demo component', () => {
     });
 
     fixture = TestBed.createComponent(DemoFixtureComponent);
+  });
+
+  it('should allow for custom headings', () => {
+    fixture.detectChanges();
+
+    const headingElement = fixture.nativeElement.querySelector('[data-test-selector="sky-docs-demo-heading-text"]');
+
+    fixture.componentInstance.heading = undefined;
+    fixture.detectChanges();
+
+    expect(headingElement).toHaveText('Demo');
+
+    fixture.componentInstance.heading = 'Foobar';
+    fixture.detectChanges();
+
+    expect(headingElement).toHaveText('Foobar');
   });
 
   describe('control panel component', () => {

--- a/src/app/public/modules/demo/demo.component.ts
+++ b/src/app/public/modules/demo/demo.component.ts
@@ -32,6 +32,10 @@ import {
 })
 export class SkyDocsDemoComponent {
 
+  /**
+   * Specifies the horizontal alignment of the demo contents.
+   * @default 'left'
+   */
   @Input()
   public set alignContents(value: SkyDocsDemoContentAlignment) {
     this._alignContents = value;
@@ -40,6 +44,12 @@ export class SkyDocsDemoComponent {
   public get alignContents(): SkyDocsDemoContentAlignment {
     return this._alignContents || 'left';
   }
+
+  /**
+   * Custom heading text for the demo.
+   */
+  @Input()
+  public heading: string;
 
   public get hasOptions(): boolean {
     return this.controlPanels && this.controlPanels.length > 0;

--- a/src/app/public/modules/demo/fixtures/demo.component.fixture.html
+++ b/src/app/public/modules/demo/fixtures/demo.component.fixture.html
@@ -1,4 +1,6 @@
-<sky-docs-demo>
+<sky-docs-demo
+  [heading]="heading"
+>
   <sky-docs-demo-control-panel
     (reset)="onDemoReset()"
     (selectionChange)="onDemoSelectionChange($event)"

--- a/src/app/public/modules/demo/fixtures/demo.component.fixture.ts
+++ b/src/app/public/modules/demo/fixtures/demo.component.fixture.ts
@@ -23,6 +23,8 @@ export class DemoFixtureComponent {
     showIcon?: boolean;
   } = {};
 
+  public heading: string;
+
   public onDemoReset(): void { }
 
   public onDemoSelectionChange(): void { }


### PR DESCRIPTION
Allows the consumer to provide custom heading text for the `sky-docs-demo` component.
```
<sky-docs-demo heading="My heading">
```