### PR TITLE
Added modern property to SkyDocsComponentInfo

### DIFF
--- a/src/app/public/modules/shared/docs-tools-component-info.ts
+++ b/src/app/public/modules/shared/docs-tools-component-info.ts
@@ -9,4 +9,5 @@ export interface SkyDocsComponentInfo {
   summary?: string;
   thumbnail?: string;
   url?: string;
+  modern?: string;
 }

--- a/src/app/public/modules/shared/docs-tools-component-info.ts
+++ b/src/app/public/modules/shared/docs-tools-component-info.ts
@@ -4,10 +4,10 @@
 export interface SkyDocsComponentInfo {
   children?: SkyDocsComponentInfo[];
   icon?: string;
+  modern?: boolean;
   name?: string;
   restricted?: boolean;
   summary?: string;
   thumbnail?: string;
   url?: string;
-  modern?: string;
 }


### PR DESCRIPTION
Made to match the supportal service:
https://blackbaud.visualstudio.com/Products/_git/sky-skysp-svc?path=%2Fsrc%2FBlackbaud.SkyUX.SupportalService%2FModels%2FDocsComponentInfo.cs&version=GBmaster&line=14&lineEnd=15&lineStartColumn=1&lineEndColumn=1&lineStyle=plain