### PR TITLE
Create thumbnail module for isolated use

### DIFF
--- a/src/app/app-extras.module.ts
+++ b/src/app/app-extras.module.ts
@@ -10,6 +10,7 @@ import {
 // Do not import from public_api since the SKY UX plugin needs to assign providers from the same place.
 // (The SKY UX plugin pulls types from node_modules.)
 import {
+  SkyDocsThumbnailModule,
   SkyDocsToolsModule,
   SkyDocsToolsOptions
 } from '@skyux/docs-tools'; // <-- Important!
@@ -33,7 +34,8 @@ import {
     SkyCodeBlockModule,
     SkyCodeModule,
     SkyDocsToolsModule,
-    SkyPopoverModule
+    SkyPopoverModule,
+    SkyDocsThumbnailModule
   ],
   providers: [
     {

--- a/src/app/app-extras.module.ts
+++ b/src/app/app-extras.module.ts
@@ -10,7 +10,6 @@ import {
 // Do not import from public_api since the SKY UX plugin needs to assign providers from the same place.
 // (The SKY UX plugin pulls types from node_modules.)
 import {
-  SkyDocsThumbnailModule,
   SkyDocsToolsModule,
   SkyDocsToolsOptions
 } from '@skyux/docs-tools'; // <-- Important!
@@ -27,15 +26,19 @@ import {
   SkyAppLinkModule
 } from '@skyux/router';
 
+import {
+  SkyDocsThumbnailModule
+} from './public/public_api';
+
 @NgModule({
   exports: [
     SkyAlertModule,
     SkyAppLinkModule,
     SkyCodeBlockModule,
     SkyCodeModule,
+    SkyDocsThumbnailModule,
     SkyDocsToolsModule,
-    SkyPopoverModule,
-    SkyDocsThumbnailModule
+    SkyPopoverModule
   ],
   providers: [
     {

--- a/src/app/docs/sample/sample.component.html
+++ b/src/app/docs/sample/sample.component.html
@@ -175,6 +175,47 @@
       </sky-docs-design-guideline>
     </sky-docs-demo-page-section>
 
+    <sky-docs-demo-page-section
+      heading="Behavior and states"
+    >
+      <sky-docs-design-guideline
+        heading="States"
+      >
+        <table class="sky-docs-table">
+          <tr>
+            <td class="sky-docs-table-cell sky-docs-table-cell-primary">
+              Base
+            </td>
+            <td class="sky-docs-table-cell">
+              <sky-docs-thumbnail
+                imageSource="~/assets/img/guidelines/popover/content-dont-overload.png"
+              ></sky-docs-thumbnail>
+            </td>
+          </tr>
+          <tr>
+            <td class="sky-docs-table-cell sky-docs-table-cell-primary">
+              Attached image
+            </td>
+            <td class="sky-docs-table-cell">
+              <sky-docs-thumbnail
+                imageSource="~/assets/img/guidelines/popover/content-dont-overload.png"
+              ></sky-docs-thumbnail>
+            </td>
+          </tr>
+          <tr>
+            <td class="sky-docs-table-cell sky-docs-table-cell-primary">
+              Attached non-image
+            </td>
+            <td class="sky-docs-table-cell">
+              <sky-docs-thumbnail
+                imageSource="~/assets/img/guidelines/popover/content-dont-overload.png"
+              ></sky-docs-thumbnail>
+            </td>
+          </tr>
+        </table>
+      </sky-docs-design-guideline>
+    </sky-docs-demo-page-section>
+
     <h3>
       Table styles with column headers
     </h3>

--- a/src/app/public/modules/design-guidelines/design-guideline-thumbnail.component.html
+++ b/src/app/public/modules/design-guidelines/design-guideline-thumbnail.component.html
@@ -1,23 +1,10 @@
 <div class="sky-docs-design-guideline-thumbnail">
-  <sky-image *ngIf="imageSource"
-    [imageSource]="imageSource"
-    [imageAlt]="imageAlt"
+  <sky-docs-thumbnail
     [caption]="caption"
     [captionType]="captionType"
+    [imageAlt]="imageAlt"
+    [imageSource]="imageSource"
+    [videoSource]="videoSource"
     [showBorder]="showBorder"
-    [showCaptionPrefix]="false"
-  ></sky-image>
-  <div *ngIf="videoSource"
-    class="sky-docs-design-guideline-video"
-    [ngClass]="{
-      'sky-docs-design-guideline-video-border': showBorder
-    }"
-  >
-    <video controls>
-      <source
-        [attr.src]="videoSource"
-        type="video/mp4"
-      />
-    </video>
-  </div>
+  ></sky-docs-thumbnail>
 </div>

--- a/src/app/public/modules/design-guidelines/design-guidelines.module.ts
+++ b/src/app/public/modules/design-guidelines/design-guidelines.module.ts
@@ -7,12 +7,12 @@ import {
 } from '@angular/core';
 
 import {
-  SkyImageModule
-} from '@blackbaud/skyux-lib-media';
-
-import {
   SkyFluidGridModule
 } from '@skyux/layout';
+
+import {
+  SkyDocsThumbnailModule
+} from '../thumbnail/thumbnail.module';
 
 import {
   SkyDocsDesignGuidelineComponent
@@ -29,8 +29,8 @@ import {
 @NgModule({
   imports: [
     CommonModule,
-    SkyFluidGridModule,
-    SkyImageModule
+    SkyDocsThumbnailModule,
+    SkyFluidGridModule
   ],
   declarations: [
     SkyDocsDesignGuidelineComponent,

--- a/src/app/public/modules/thumbnail/thumbnail.component.html
+++ b/src/app/public/modules/thumbnail/thumbnail.component.html
@@ -1,0 +1,23 @@
+<div class="sky-docs-thumbnail">
+  <sky-image *ngIf="imageSource"
+    [imageSource]="imageSource"
+    [imageAlt]="imageAlt"
+    [caption]="caption"
+    [captionType]="captionType"
+    [showBorder]="showBorder"
+    [showCaptionPrefix]="false"
+  ></sky-image>
+  <div *ngIf="videoSource"
+    class="sky-docs-video"
+    [ngClass]="{
+      'sky-docs-video-border': showBorder
+    }"
+  >
+    <video controls>
+      <source
+        [attr.src]="videoSource"
+        type="video/mp4"
+      />
+    </video>
+  </div>
+</div>

--- a/src/app/public/modules/thumbnail/thumbnail.component.html
+++ b/src/app/public/modules/thumbnail/thumbnail.component.html
@@ -1,9 +1,9 @@
 <div class="sky-docs-thumbnail">
   <sky-image *ngIf="imageSource"
-    [imageSource]="imageSource"
-    [imageAlt]="imageAlt"
     [caption]="caption"
     [captionType]="captionType"
+    [imageAlt]="imageAlt"
+    [imageSource]="imageSource"
     [showBorder]="showBorder"
     [showCaptionPrefix]="false"
   ></sky-image>

--- a/src/app/public/modules/thumbnail/thumbnail.component.scss
+++ b/src/app/public/modules/thumbnail/thumbnail.component.scss
@@ -1,0 +1,18 @@
+@import '~@skyux/theme/scss/mixins';
+@import '~@skyux/theme/scss/_compat/mixins';
+
+.sky-docs-thumbnail {
+  margin-bottom: $sky-margin * 5;
+}
+
+.sky-docs-video {
+  video {
+    max-width: 100%;
+  }
+}
+
+.sky-docs-video-border {
+  video {
+    @include sky-border(light, top, right, bottom, left);
+  }
+}

--- a/src/app/public/modules/thumbnail/thumbnail.component.ts
+++ b/src/app/public/modules/thumbnail/thumbnail.component.ts
@@ -25,9 +25,9 @@ export class SkyDocsThumbnailComponent {
   public imageSource: string;
 
   @Input()
-  public videoSource: string;
+  public showBorder: boolean = false;
 
   @Input()
-  public showBorder: boolean = false;
+  public videoSource: string;
 
 }

--- a/src/app/public/modules/thumbnail/thumbnail.component.ts
+++ b/src/app/public/modules/thumbnail/thumbnail.component.ts
@@ -1,0 +1,33 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input
+} from '@angular/core';
+
+@Component({
+  selector: 'sky-docs-thumbnail',
+  templateUrl: './thumbnail.component.html',
+  styleUrls: ['./thumbnail.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SkyDocsThumbnailComponent {
+
+  @Input()
+  public caption: string;
+
+  @Input()
+  public captionType: string;
+
+  @Input()
+  public imageAlt: string;
+
+  @Input()
+  public imageSource: string;
+
+  @Input()
+  public videoSource: string;
+
+  @Input()
+  public showBorder: boolean = false;
+
+}

--- a/src/app/public/modules/thumbnail/thumbnail.module.ts
+++ b/src/app/public/modules/thumbnail/thumbnail.module.ts
@@ -1,0 +1,29 @@
+import {
+  CommonModule
+} from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyImageModule
+} from '@blackbaud/skyux-lib-media';
+
+import {
+  SkyDocsThumbnailComponent
+} from './thumbnail.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SkyImageModule
+  ],
+  exports: [
+    SkyDocsThumbnailComponent
+  ],
+  declarations: [
+    SkyDocsThumbnailComponent
+  ]
+})
+export class SkyDocsThumbnailModule {}

--- a/src/app/public/public_api.ts
+++ b/src/app/public/public_api.ts
@@ -24,6 +24,8 @@ export * from './modules/shared/docs-tools-supportal.service';
 
 export * from './modules/source-code/source-code-provider';
 
+export * from './modules/thumbnail/thumbnail.module';
+
 export * from './modules/type-definitions/class-definition';
 export * from './modules/type-definitions/directive-definition';
 export * from './modules/type-definitions/enumeration-definition';


### PR DESCRIPTION
- Currently, the only way to add an image to the SPA is to use the `sky-docs-design-guideline-thumbnail`, but it carries specific use-cases and positioning. We have a need for an image component that can be used anywhere.