### PR TITLE
Add support for latest version of marked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,21 +1606,21 @@
       }
     },
     "@skyux/docs-tools": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@skyux/docs-tools/-/docs-tools-4.4.3.tgz",
-      "integrity": "sha512-Sa2JkyXcPXNzNH58FsxmxtirWlscTLxH3BmITe9ck1b2AxoEi6g2skwhepbQYa1dUX4fLZ8EZ7dY3zjY8EYkPg==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@skyux/docs-tools/-/docs-tools-4.4.4.tgz",
+      "integrity": "sha512-ZT9MxuCeJSGTzJZj6yyOIxqc05kXAVhQnAzs8oVthyKzCdgUT4d5Hbka11R3I1P9t15QHrPT9ll/LLF+ozvS0w==",
       "dev": true,
       "requires": {
         "@stackblitz/sdk": "1.5.0",
         "lodash.orderby": "4.6.0",
-        "marked": "0.8.2",
+        "marked": "0.8.0",
         "tslib": "^1.10.0"
       },
       "dependencies": {
         "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+          "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==",
           "dev": true
         }
       }
@@ -1869,6 +1869,12 @@
       "requires": {
         "@types/lodash": "*"
       }
+    },
+    "@types/marked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-1.1.0.tgz",
+      "integrity": "sha512-j8XXj6/l9kFvCwMyVqozznqpd/nk80krrW+QiIJN60Uu9gX5Pvn4/qPJ2YngQrR3QREPwmrE1f9/EWKVTFzoEw==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -7979,9 +7985,9 @@
       }
     },
     "marked": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
-      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
     },
     "marky": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@stackblitz/sdk": "1.5.0",
     "lodash.orderby": "4.6.0",
-    "marked": "0.8.0"
+    "marked": "1.1.1"
   },
   "devDependencies": {
     "@angular/animations": "9.1.12",
@@ -68,7 +68,7 @@
     "@skyux/avatar": "4.1.0",
     "@skyux/config": "4.0.3",
     "@skyux/core": "4.3.0",
-    "@skyux/docs-tools": "4.4.3",
+    "@skyux/docs-tools": "4.4.4",
     "@skyux/errors": "4.0.1",
     "@skyux/forms": "4.9.0",
     "@skyux/http": "4.0.1",
@@ -85,6 +85,7 @@
     "@skyux/tabs": "4.3.2",
     "@skyux/theme": "4.10.2",
     "@types/lodash.orderby": "4.6.6",
+    "@types/marked": "1.1.0",
     "codelyzer": "5.2.2",
     "node-sass-tilde-importer": "1.0.2",
     "rxjs": "6.6.2",

--- a/src/app/public/modules/markdown/markdown.pipe.ts
+++ b/src/app/public/modules/markdown/markdown.pipe.ts
@@ -3,20 +3,16 @@ import {
   PipeTransform
 } from '@angular/core';
 
-const marked = require('marked/lib/marked.js');
+import marked from 'marked';
 
 @Pipe({
   name: 'skyDocsMarkdown'
 })
 export class SkyDocsMarkdownPipe implements PipeTransform {
 
-  public transform(markdown: string, parsingMode: 'inline' | 'block' = 'block'): string {
+  public transform(markdown: string): string {
     if (!markdown) {
       return '';
-    }
-
-    if (parsingMode === 'inline') {
-      return marked.inlineLexer(markdown, []);
     }
 
     return marked(markdown);

--- a/src/app/public/modules/type-definitions/property-definitions.component.html
+++ b/src/app/public/modules/type-definitions/property-definitions.component.html
@@ -77,13 +77,10 @@
     class="sky-docs-property-definition-label sky-text-danger"
   >Required.</p>
 
-  <p *ngIf="property.deprecationWarning !== undefined"
-    class="sky-docs-property-definition-label sky-text-warning"
-  >
-    <strong>Deprecated.</strong>&nbsp;<span
-      [innerHtml]="property.deprecationWarning | skyDocsMarkdown:'inline' | skyDocsTypeAnchorLinks"
-    ></span>
-  </p>
+  <sky-docs-safe-html *ngIf="property.deprecationWarning !== undefined"
+    class="sky-docs-property-definitions-deprecation-warning"
+    [innerHtml]="deprecationWarningPrefix + property.deprecationWarning | skyDocsMarkdown | skyDocsTypeAnchorLinks"
+  ></sky-docs-safe-html>
 
   <ng-container
     [ngTemplateOutlet]="property.templateRef"

--- a/src/app/public/modules/type-definitions/property-definitions.component.spec.ts
+++ b/src/app/public/modules/type-definitions/property-definitions.component.spec.ts
@@ -141,7 +141,7 @@ describe('Property definitions component', function () {
     tick();
 
     const descriptionElement = fixture.nativeElement.querySelector(
-      '.sky-docs-property-definitions-table-cell-description .sky-text-warning'
+      '.sky-docs-property-definitions-deprecation-warning'
     );
 
     expect(descriptionElement.innerText).toContain(

--- a/src/app/public/modules/type-definitions/property-definitions.component.spec.ts
+++ b/src/app/public/modules/type-definitions/property-definitions.component.spec.ts
@@ -158,7 +158,7 @@ describe('Property definitions component', function () {
     tick();
 
     const descriptionElement = fixture.nativeElement.querySelector(
-      '.sky-docs-property-definitions-table-cell-description .sky-text-warning'
+      '.sky-docs-property-definitions-deprecation-warning'
     );
 
     expect(descriptionElement.innerHTML).toContain([

--- a/src/app/public/modules/type-definitions/property-definitions.component.ts
+++ b/src/app/public/modules/type-definitions/property-definitions.component.ts
@@ -37,6 +37,8 @@ export class SkyDocsPropertyDefinitionsComponent implements OnInit, AfterContent
   @Input()
   public propertyType = 'Property';
 
+  public deprecationWarningPrefix = `<span class="sky-text-warning"></span>**Deprecated.** `;
+
   public isMobile: boolean = true;
 
   public properties: SkyDocsPropertyDefinition[] = [];


### PR DESCRIPTION
TypeDoc is pulling in the latest version of `marked` (`1.1.1`) and I believe it's causing problems with our markdown pipe. We're seeing the following error:
```
marked__WEBPACK_IMPORTED_MODULE_19___default.a.inlineLexer is not a function
```

The latest version of marked removed the inline lexer functionality, so I had to adjust the pipe accordingly.