### PR TITLE
Provide SkyThemeService for StackBlitz demos, regardless of theme

### DIFF
--- a/src/app/public/modules/code-examples/code-examples-editor.service.spec.ts
+++ b/src/app/public/modules/code-examples/code-examples-editor.service.spec.ts
@@ -18,7 +18,7 @@ import {
 
 describe('Code examples editor service', () => {
 
-  it('should provide SkyThemeService when theme property is set to Modern', () => {
+  it('should set SkyTheme to modern when theme property is set to Modern', () => {
     const service = new SkyDocsCodeExamplesEditorService();
     const stackblitzSpy = spyOn(StackBlitzSDK, 'openProject').and.callFake(() => {});
     const codeExample: SkyDocsCodeExample = {
@@ -38,11 +38,11 @@ describe('Code examples editor service', () => {
 
     expect(stackblitzSpy).toHaveBeenCalled();
     const spyArgs = stackblitzSpy.calls.mostRecent().args;
-    expect(spyArgs[0].files['src/app/app.component.ts']).toContain('SkyThemeService');
+    expect(spyArgs[0].files['src/app/app.component.ts']).toContain(`SkyTheme.presets['modern']`);
     expect(spyArgs[0].files['src/app/app.module.ts']).toContain('SkyThemeService');
   });
 
-  it('should NOT provide SkyThemeService when theme property is set to Default', () => {
+  it('should SkyTheme to default when theme property is set to Default', () => {
     const service = new SkyDocsCodeExamplesEditorService();
     const stackblitzSpy = spyOn(StackBlitzSDK, 'openProject').and.callFake(() => {});
     const codeExample: SkyDocsCodeExample = {
@@ -62,8 +62,8 @@ describe('Code examples editor service', () => {
 
     expect(stackblitzSpy).toHaveBeenCalled();
     const spyArgs = stackblitzSpy.calls.mostRecent().args;
-    expect(spyArgs[0].files['src/app/app.component.ts']).not.toContain('SkyThemeService');
-    expect(spyArgs[0].files['src/app/app.module.ts']).not.toContain('SkyThemeService');
+    expect(spyArgs[0].files['src/app/app.component.ts']).toContain(`SkyTheme.presets['default']`);
+    expect(spyArgs[0].files['src/app/app.module.ts']).toContain('SkyThemeService');
   });
 
 });

--- a/src/app/public/modules/code-examples/code-examples-editor.service.spec.ts
+++ b/src/app/public/modules/code-examples/code-examples-editor.service.spec.ts
@@ -16,23 +16,136 @@ import {
   SkyDocsCodeExampleTheme
 } from './code-example-theme';
 
+//#region helpers
+const moduleImports: string[] = [
+  'BrowserModule',
+  'FormsModule',
+  'ReactiveFormsModule',
+  'RouterModule.forRoot([])'
+];
+
+const sampleModuleContents: string = `
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SampleDemoComponent
+} from './foo.component';
+
+@NgModule({
+  declarations: [
+    SampleDemoComponent
+  ],
+  exports: [
+    SampleDemoComponent
+  ]
+})
+export class SampleDemoModule {}
+`;
+
+const sampleModuleContentsNoExports: string = `
+import {
+  NgModule
+} from '@angular/core';
+
+@NgModule({})
+export class SampleDemoModule {}
+`;
+
+const sampleComponentContents: string = `
+import {
+  Component
+} from '@angular/core';
+
+@Component({
+  selector: 'app-sample-demo',
+  template: ''
+})
+export class SampleDemoComponent {}`;
+
+const sampleModuleContentsMultipleExports: string = `
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SampleDemoComponent
+} from './foo.component';
+
+import {
+  BarComponent
+} from './bar.component';
+
+@NgModule({
+  declarations: [
+    SampleDemoComponent,
+    BarComponent
+  ],
+  exports: [
+    SampleDemoComponent,
+    BarComponent
+  ]
+})
+export class SampleDemoModule {}
+`;
+
+const codeExample: SkyDocsCodeExample = {
+  heading: 'Basic example',
+  packageDependencies: {},
+  sourceCode: [
+    {
+      fileName: 'foo.component.ts',
+      filePath: './',
+      rawContents: sampleComponentContents
+    },
+    {
+      fileName: 'foo.module.ts',
+      filePath: './',
+      rawContents: sampleModuleContents
+    }
+  ],
+  theme: SkyDocsCodeExampleTheme.Default
+};
+
+const codeExampleNoExports: SkyDocsCodeExample = {
+  heading: 'Basic example',
+  packageDependencies: {},
+  sourceCode: [
+    {
+      fileName: 'foo.module.ts',
+      filePath: './',
+      rawContents: sampleModuleContentsNoExports
+    }
+  ],
+  theme: SkyDocsCodeExampleTheme.Default
+};
+
+const codeExampleMultipleExports: SkyDocsCodeExample = {
+  heading: 'Basic example',
+  packageDependencies: {},
+  sourceCode: [
+    {
+      fileName: 'foo.module.ts',
+      filePath: './',
+      rawContents: sampleModuleContentsMultipleExports
+    }
+  ],
+  theme: SkyDocsCodeExampleTheme.Default
+};
+//#endregion
+
 describe('Code examples editor service', () => {
+  let stackblitzSpy: jasmine.Spy;
+  let service: SkyDocsCodeExamplesEditorService;
+
+  beforeEach(() => {
+    stackblitzSpy = spyOn(StackBlitzSDK, 'openProject').and.callFake(() => {});
+    service = new SkyDocsCodeExamplesEditorService();
+  });
 
   it('should set SkyTheme to modern when theme property is set to Modern', () => {
-    const service = new SkyDocsCodeExamplesEditorService();
-    const stackblitzSpy = spyOn(StackBlitzSDK, 'openProject').and.callFake(() => {});
-    const codeExample: SkyDocsCodeExample = {
-      heading: 'foo',
-      packageDependencies: {},
-      sourceCode: [
-        {
-          fileName: 'foo.component.ts',
-          filePath: 'foo',
-          rawContents: 'These are my file contents!'
-        }
-      ],
-      theme: SkyDocsCodeExampleTheme.Modern
-    };
+    codeExample.theme = SkyDocsCodeExampleTheme.Modern;
 
     service.launchEditor(codeExample);
 
@@ -43,20 +156,7 @@ describe('Code examples editor service', () => {
   });
 
   it('should set SkyTheme to default when theme property is set to Default', () => {
-    const service = new SkyDocsCodeExamplesEditorService();
-    const stackblitzSpy = spyOn(StackBlitzSDK, 'openProject').and.callFake(() => {});
-    const codeExample: SkyDocsCodeExample = {
-      heading: 'foo',
-      packageDependencies: {},
-      sourceCode: [
-        {
-          fileName: 'foo.component.ts',
-          filePath: 'foo',
-          rawContents: 'These are my file contents!'
-        }
-      ],
-      theme: SkyDocsCodeExampleTheme.Default
-    };
+    codeExample.theme = SkyDocsCodeExampleTheme.Default;
 
     service.launchEditor(codeExample);
 
@@ -64,6 +164,32 @@ describe('Code examples editor service', () => {
     const spyArgs = stackblitzSpy.calls.mostRecent().args;
     expect(spyArgs[0].files['src/app/app.component.ts']).toContain(`SkyTheme.presets['default']`);
     expect(spyArgs[0].files['src/app/app.module.ts']).toContain('SkyThemeService');
+  });
+
+  it('should add modules from code example to app.module.ts', () => {
+    moduleImports.push('SampleDemoModule');
+
+    service.launchEditor(codeExample);
+
+    expect(stackblitzSpy).toHaveBeenCalled();
+    const spyArgs = stackblitzSpy.calls.mostRecent().args;
+    expect(spyArgs[0].files['src/app/app.module.ts']).toContain(`import {\n  SampleDemoModule\n} from './foo.module';`);
+    expect(spyArgs[0].files['src/app/app.module.ts']).toContain(`imports: [\n    ${moduleImports.join(',\n    ')}`);
+  });
+
+  it('should throw an error if code example module does not have any exports', () => {
+    expect(() => {
+      service.launchEditor(codeExampleNoExports);
+    }).toThrow('You must export a component from the code example module!');
+  });
+
+  it('should throw an error if code example module has multiple exports', () => {
+    try {
+      service.launchEditor(codeExampleMultipleExports);
+      fail('Expected test to throw error!');
+    } catch (error) {
+      expect(error).toContain('You may only export a single component from the code example module');
+    }
   });
 
 });

--- a/src/app/public/modules/code-examples/code-examples-editor.service.spec.ts
+++ b/src/app/public/modules/code-examples/code-examples-editor.service.spec.ts
@@ -42,7 +42,7 @@ describe('Code examples editor service', () => {
     expect(spyArgs[0].files['src/app/app.module.ts']).toContain('SkyThemeService');
   });
 
-  it('should SkyTheme to default when theme property is set to Default', () => {
+  it('should set SkyTheme to default when theme property is set to Default', () => {
     const service = new SkyDocsCodeExamplesEditorService();
     const stackblitzSpy = spyOn(StackBlitzSDK, 'openProject').and.callFake(() => {});
     const codeExample: SkyDocsCodeExample = {

--- a/src/app/public/modules/code-examples/code-examples-editor.service.ts
+++ b/src/app/public/modules/code-examples/code-examples-editor.service.ts
@@ -178,22 +178,21 @@ import {
 export class AppComponent {
 
   constructor(
-    renderer?: Renderer2,
-    private themeSvc?: SkyThemeService
+    themeSvc: SkyThemeService,
+    renderer?: Renderer2
   ) {
-    if (themeSvc) {
       const themeSettings = new SkyThemeSettings(
-      SkyTheme.presets['${theme === SkyDocsCodeExampleTheme.Modern ? 'modern' : 'default'}'],
-      SkyThemeMode.presets.light
-    );
+        SkyTheme.presets['${theme === SkyDocsCodeExampleTheme.Modern ? 'modern' : 'default'}'],
+        SkyThemeMode.presets.light
+      );
 
-      this.themeSvc.init(
+      themeSvc.init(
         document.body,
         renderer,
         themeSettings
       );
-    }
   }
+
 }`;
 
     files[`${appPath}app.module.ts`] = `${moduleImportStatements.join('\n\n')}

--- a/src/app/public/modules/code-examples/code-examples-editor.service.ts
+++ b/src/app/public/modules/code-examples/code-examples-editor.service.ts
@@ -124,12 +124,10 @@ export class SkyDocsCodeExamplesEditorService {
       `import {\n  BrowserModule\n} from '@angular/platform-browser';`,
       `import {\n  RouterModule\n} from '@angular/router';`,
       `import {\n  SkyAppLocaleProvider\n} from '@skyux/i18n';`,
+      `import {\n  SkyThemeService\n} from '@skyux/theme';`,
       `import {\n  of as observableOf\n} from 'rxjs';`,
       `import {\n  AppComponent\n} from './app.component';`
     ];
-    if (theme === SkyDocsCodeExampleTheme.Modern) {
-      moduleImportStatements.push(`import {\n  SkyThemeService\n} from '@skyux/theme';`);
-    }
 
     const moduleImports: string[] = [
       'BrowserModule',
@@ -160,7 +158,6 @@ export class SkyDocsCodeExamplesEditorService {
       }
     });
 
-    if (theme === SkyDocsCodeExampleTheme.Modern) {
       files[`${appPath}app.component.ts`] = `${banner}
 import {
   Component,
@@ -186,7 +183,7 @@ export class AppComponent {
   ) {
     if (themeSvc) {
       const themeSettings = new SkyThemeSettings(
-      SkyTheme.presets['modern'],
+      SkyTheme.presets[${theme === SkyDocsCodeExampleTheme.Modern ? `'modern'` : `'default'`}],
       SkyThemeMode.presets.light
     );
 
@@ -198,18 +195,6 @@ export class AppComponent {
     }
   }
 }`;
-    } else {
-      files[`${appPath}app.component.ts`] = `${banner}
-import {
-  Component
-} from '@angular/core';
-
-@Component({
-  selector: 'sky-demo-app',
-  template: '${appComponentTemplate}'
-})
-export class AppComponent {}`;
-    }
 
     files[`${appPath}app.module.ts`] = `${moduleImportStatements.join('\n\n')}
 
@@ -223,7 +208,8 @@ export class AppComponent {}`;
   bootstrap: [
     AppComponent
   ],
-  providers: [${theme === SkyDocsCodeExampleTheme.Modern ? '\n    SkyThemeService,' : ''}
+  providers: [
+    SkyThemeService,
     {
       provide: SkyAppLocaleProvider,
       useValue: {

--- a/src/app/public/modules/code-examples/code-examples-editor.service.ts
+++ b/src/app/public/modules/code-examples/code-examples-editor.service.ts
@@ -183,7 +183,7 @@ export class AppComponent {
   ) {
     if (themeSvc) {
       const themeSettings = new SkyThemeSettings(
-      SkyTheme.presets[${theme === SkyDocsCodeExampleTheme.Modern ? `'modern'` : `'default'`}],
+      SkyTheme.presets['${theme === SkyDocsCodeExampleTheme.Modern ? 'modern' : 'default'}'],
       SkyThemeMode.presets.light
     );
 


### PR DESCRIPTION
Some components, like Input Box, expects `SkyThemeService` to be provided by the host SPA. Loading a stackblitz demo with an input box in default theme will throw a `No provider found` error for the service. This will ensure `SkyThemeService` is always provided, regardless of the theme being used.