### PR TITLE
Code examples use SkyThemeService to determine theme

### DIFF
--- a/src/app/public/modules/code-examples/code-example.component.spec.ts
+++ b/src/app/public/modules/code-examples/code-example.component.spec.ts
@@ -49,7 +49,7 @@ describe('Code example component', () => {
     fixture = TestBed.createComponent(CodeExampleFixtureComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    codeExampleComponent = component.codeExampleComponents.first;
+    codeExampleComponent = component.codeExampleComponents;
   });
 
   it('should default theme property to default', () => {

--- a/src/app/public/modules/code-examples/code-example.component.spec.ts
+++ b/src/app/public/modules/code-examples/code-example.component.spec.ts
@@ -1,0 +1,111 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+
+import {
+  expect
+} from '@skyux-sdk/testing';
+
+import {
+  SkyTheme,
+  SkyThemeMode,
+  SkyThemeService,
+  SkyThemeSettings
+} from '@skyux/theme';
+
+import {
+  SkyDocsCodeExampleTheme
+} from './code-example-theme';
+
+import {
+  CodeExampleFixtureComponent
+} from './fixtures/code-example-fixture.component';
+
+import {
+  CodeExampleFixturesModule
+} from './fixtures/code-example-fixtures.module';
+
+import {
+  CodeExampleWithThemeServiceFixtureComponent
+} from './fixtures/code-example-with-theme-service-fixture.component';
+
+import {
+  SkyDocsCodeExampleComponent
+} from './code-example.component';
+
+describe('Code example component', () => {
+  let fixture: ComponentFixture<CodeExampleFixtureComponent>;
+  let component: CodeExampleFixtureComponent;
+  let codeExampleComponent: SkyDocsCodeExampleComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CodeExampleFixturesModule
+      ]
+    });
+
+    fixture = TestBed.createComponent(CodeExampleFixtureComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    codeExampleComponent = component.codeExampleComponents.first;
+  });
+
+  it('should default theme property to default', () => {
+    expect(codeExampleComponent.theme).toEqual(SkyDocsCodeExampleTheme.Default);
+  });
+
+  it('should set theme property', () => {
+    component.theme = 'modern';
+    fixture.detectChanges();
+
+    expect(codeExampleComponent.theme).toEqual(SkyDocsCodeExampleTheme.Modern);
+  });
+
+  it('should allow resetting of theme setting', () => {
+    component.theme = 'modern';
+    fixture.detectChanges();
+
+    expect(codeExampleComponent.theme).toEqual(SkyDocsCodeExampleTheme.Modern);
+
+    component.theme = undefined;
+    fixture.detectChanges();
+
+    expect(codeExampleComponent.theme).toEqual(SkyDocsCodeExampleTheme.Default);
+  });
+});
+
+describe('Code example component with SkyThemeService', () => {
+  let fixture: ComponentFixture<CodeExampleWithThemeServiceFixtureComponent>;
+  let component: CodeExampleWithThemeServiceFixtureComponent;
+  let codeExampleComponent: SkyDocsCodeExampleComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        CodeExampleFixturesModule
+      ],
+      providers: [
+        SkyThemeService
+      ]
+    });
+
+    fixture = TestBed.createComponent(CodeExampleWithThemeServiceFixtureComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    codeExampleComponent = component.codeExampleComponents.first;
+  });
+
+  it('should update theme property using SkyThemeService', () => {
+    expect(codeExampleComponent.theme).toEqual(SkyDocsCodeExampleTheme.Modern);
+
+    component.setTheme(new SkyThemeSettings(
+      SkyTheme.presets.default,
+      SkyThemeMode.presets.light
+    ));
+    fixture.detectChanges();
+
+    expect(codeExampleComponent.theme).toEqual(SkyDocsCodeExampleTheme.Default);
+  });
+});

--- a/src/app/public/modules/code-examples/code-example.component.ts
+++ b/src/app/public/modules/code-examples/code-example.component.ts
@@ -1,8 +1,13 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Input
+  Input,
+  Optional
 } from '@angular/core';
+
+import {
+  SkyThemeService
+} from '@skyux/theme';
 
 import {
   SkyDocsCodeExampleTheme
@@ -42,8 +47,32 @@ export class SkyDocsCodeExampleComponent {
 
   /**
    * Specifies if the editor service should show the example in modern theme.
+   * The value will be gleaned from `SkyThemeService` first, then fallback to 'default' if the service is not found.
    */
   @Input()
-  public theme: SkyDocsCodeExampleTheme = SkyDocsCodeExampleTheme.Default;
+  public set theme(value: SkyDocsCodeExampleTheme) {
+    this._theme = value;
+  }
+
+  public get theme(): SkyDocsCodeExampleTheme {
+    return this._theme || SkyDocsCodeExampleTheme.Default;
+  }
+
+  private _theme: SkyDocsCodeExampleTheme;
+
+  constructor(
+    @Optional() themeSvc?: SkyThemeService
+  ) {
+    // Update theme property with SkyThemeService if it has not been set.
+    if (!this._theme && themeSvc) {
+      themeSvc.settingsChange.subscribe(change => {
+        if (change.currentSettings.theme.name === 'modern') {
+          this.theme = SkyDocsCodeExampleTheme.Modern;
+        } else if (change.currentSettings.theme.name === 'default') {
+          this.theme = SkyDocsCodeExampleTheme.Default;
+        }
+      });
+    }
+  }
 
 }

--- a/src/app/public/modules/code-examples/code-example.component.ts
+++ b/src/app/public/modules/code-examples/code-example.component.ts
@@ -67,7 +67,7 @@ export class SkyDocsCodeExampleComponent implements OnDestroy {
     return this._theme || SkyDocsCodeExampleTheme.Default;
   }
 
-  private ngUnsubscribe = new Subject<boolean>();
+  private ngUnsubscribe = new Subject<void>();
 
   private _theme: SkyDocsCodeExampleTheme;
 

--- a/src/app/public/modules/code-examples/fixtures/code-example-fixture.component.ts
+++ b/src/app/public/modules/code-examples/fixtures/code-example-fixture.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
-  QueryList,
-  ViewChildren
+  ViewChild
 } from '@angular/core';
 
 import {
@@ -22,7 +21,7 @@ export class CodeExampleFixtureComponent {
 
   public theme: string;
 
-  @ViewChildren(SkyDocsCodeExampleComponent)
-  public codeExampleComponents: QueryList<SkyDocsCodeExampleComponent>;
+  @ViewChild(SkyDocsCodeExampleComponent)
+  public codeExampleComponents: SkyDocsCodeExampleComponent;
 
 }

--- a/src/app/public/modules/code-examples/fixtures/code-example-fixture.component.ts
+++ b/src/app/public/modules/code-examples/fixtures/code-example-fixture.component.ts
@@ -1,0 +1,28 @@
+import {
+  Component,
+  QueryList,
+  ViewChildren
+} from '@angular/core';
+
+import {
+  SkyDocsCodeExampleComponent
+} from '../../code-examples/code-example.component';
+
+@Component({
+  selector: 'code-example-fixture',
+  template: `
+    <sky-docs-code-example
+      heading="My code example"
+      sourceCodePath="src/app/public/plugin-resources/foobar"
+      [theme]="theme"
+    >
+    </sky-docs-code-example>`
+})
+export class CodeExampleFixtureComponent {
+
+  public theme: string;
+
+  @ViewChildren(SkyDocsCodeExampleComponent)
+  public codeExampleComponents: QueryList<SkyDocsCodeExampleComponent>;
+
+}

--- a/src/app/public/modules/code-examples/fixtures/code-example-fixtures.module.ts
+++ b/src/app/public/modules/code-examples/fixtures/code-example-fixtures.module.ts
@@ -1,0 +1,36 @@
+import {
+  CommonModule
+} from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
+
+import {
+  SkyDocsCodeExamplesModule
+} from '../code-examples.module';
+
+import {
+  CodeExampleFixtureComponent
+} from './code-example-fixture.component';
+
+import {
+  CodeExampleWithThemeServiceFixtureComponent
+} from './code-example-with-theme-service-fixture.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SkyDocsCodeExamplesModule
+  ],
+  exports: [
+    CodeExampleFixtureComponent,
+    CodeExampleWithThemeServiceFixtureComponent
+  ],
+  declarations: [
+    CodeExampleFixtureComponent,
+    CodeExampleWithThemeServiceFixtureComponent
+  ],
+  providers: []
+})
+export class CodeExampleFixturesModule { }

--- a/src/app/public/modules/code-examples/fixtures/code-example-with-theme-service-fixture.component.ts
+++ b/src/app/public/modules/code-examples/fixtures/code-example-with-theme-service-fixture.component.ts
@@ -1,0 +1,53 @@
+import {
+  Component,
+  ElementRef,
+  QueryList,
+  Renderer2,
+  ViewChildren
+} from '@angular/core';
+
+import {
+  SkyTheme,
+  SkyThemeMode,
+  SkyThemeService,
+  SkyThemeSettings
+} from '@skyux/theme';
+
+import {
+  SkyDocsCodeExampleComponent
+} from '../code-example.component';
+
+@Component({
+  selector: 'code-example-fixture',
+  template: `
+    <sky-docs-code-example
+      heading="My code example"
+      sourceCodePath="src/app/public/plugin-resources/foobar"
+    >
+    </sky-docs-code-example>`
+})
+export class CodeExampleWithThemeServiceFixtureComponent {
+
+  @ViewChildren(SkyDocsCodeExampleComponent)
+  public codeExampleComponents: QueryList<SkyDocsCodeExampleComponent>;
+
+  constructor(
+    private elRef: ElementRef,
+    private renderer: Renderer2,
+    private themeSvc: SkyThemeService
+  ) {
+    this.themeSvc.init(
+      this.elRef.nativeElement,
+      this.renderer,
+      new SkyThemeSettings(
+        SkyTheme.presets.modern,
+        SkyThemeMode.presets.light
+      )
+    );
+  }
+
+  public setTheme(themeSettings: SkyThemeSettings): void {
+    this.themeSvc.setTheme(themeSettings);
+  }
+
+}

--- a/src/app/public/modules/demo/demo.component.spec.ts
+++ b/src/app/public/modules/demo/demo.component.spec.ts
@@ -202,7 +202,7 @@ describe('Demo component', () => {
         );
       }
 
-      const mockAuthProvider = TestBed.inject(SkyAuthTokenProvider) as unknown as DemoAuthTokenMockProvider;
+      const mockAuthProvider = TestBed.inject(SkyAuthTokenProvider) as DemoAuthTokenMockProvider;
 
       mockAuthProvider.testToken = {
         '1bb.perms': [1]

--- a/src/app/public/modules/demo/demo.component.spec.ts
+++ b/src/app/public/modules/demo/demo.component.spec.ts
@@ -202,7 +202,7 @@ describe('Demo component', () => {
         );
       }
 
-      const mockAuthProvider = TestBed.get(SkyAuthTokenProvider) as DemoAuthTokenMockProvider;
+      const mockAuthProvider = TestBed.inject(SkyAuthTokenProvider) as unknown as DemoAuthTokenMockProvider;
 
       mockAuthProvider.testToken = {
         '1bb.perms': [1]

--- a/src/app/public/modules/demo/fixtures/demo-auth-token-mock-provider.ts
+++ b/src/app/public/modules/demo/fixtures/demo-auth-token-mock-provider.ts
@@ -4,7 +4,7 @@ import {
 
 export class DemoAuthTokenMockProvider {
 
-  public testToken: SkyAuthToken = {
+  public testToken?: SkyAuthToken = {
     '1bb.perms': []
   };
 


### PR DESCRIPTION
The code-example `theme` input property will follow these rules of specificity:
1. First, use whatever value provided by the consumer.
2. If no value is provided, use the theme service to determine what the theme should be.
3. If the theme service isn't available, default to `default` theme.