### PR TITLE
Table margins no longer applied to tables in behavioral demo

### DIFF
--- a/src/app/public/modules/demo-page/demo-page.component.scss
+++ b/src/app/public/modules/demo-page/demo-page.component.scss
@@ -7,7 +7,7 @@
       margin: $sky-margin-plus-half 0;
     }
 
-    table {
+    table:not(.sky-grid-table) {
       margin-top: $sky-margin-plus-half;
       margin-bottom: $sky-margin-plus-half;
     }

--- a/src/app/public/modules/demo-page/demo-page.component.scss
+++ b/src/app/public/modules/demo-page/demo-page.component.scss
@@ -7,11 +7,6 @@
       margin: $sky-margin-plus-half 0;
     }
 
-    table:not(.sky-grid-table) {
-      margin-top: $sky-margin-plus-half;
-      margin-bottom: $sky-margin-plus-half;
-    }
-
     .stache-max-width-container {
       max-width: none;
       margin: 0;
@@ -49,6 +44,11 @@
 
 .sky-docs-demo-page-main {
   padding: $sky-padding-triple 0;
+
+  table {
+    margin-top: $sky-margin-plus-half;
+    margin-bottom: $sky-margin-plus-half;
+  }
 
   // Make the tabset's bottom border stretch the full width of the page.
   ::ng-deep {


### PR DESCRIPTION
These styles were inadvertently giving a margin to the grid inside the demo.